### PR TITLE
DEX-8214: increase the API timeout to make the job creation more robust

### DIFF
--- a/cloudera_airflow_provider/CHANGELOG.md
+++ b/cloudera_airflow_provider/CHANGELOG.md
@@ -3,7 +3,19 @@ All notable changes to this project will be documented in this file.
  
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
- 
+
+## [2.1.0] - 2023-02-01
+
+New environment variables allow to modify the `api_retries` and
+`api_timeout` values used by the cde hook:
+- `AIRFLOW__CDE__DEFAULT_NUM_RETRIES` to set the `api_retries` value.
+- `AIRFLOW__CDE__DEFAULT_API_TIMEOUT` to set the `api_timeout` value.
+
+The value precedence is 'parameter' > 'env var' > 'airflow.cfg' > 'default'.
+
+With the environemt variables it is easier to fine tune the values without the
+need to modify the existing DAG files.
+
 ## [2.0.1] - 2023-01-02
 
 Synchronise version settings for public release.

--- a/cloudera_airflow_provider/README.md
+++ b/cloudera_airflow_provider/README.md
@@ -75,7 +75,7 @@ Connection contain parameters:
 | :--- | :---- | :--- |
 | ID | Id of the Airflow connection of the target CDW Virtual Warehouse | Simple string making the Virtual Warehouse identifiable |
 | Type | Airflow connection type | 'hive_cli'. Note: in Airflow UI it is available as "Hive Client Wrapper" |
-| Host | URL of related CDW connection | On CDW Virtual Warehouse UI: click 'More` > 'Copy JDBC connection link' |
+| Host | URL of related CDW connection | On CDW Virtual Warehouse UI: click 'More' > 'Copy JDBC connection link' |
 | Schema | Hive schema | 'default' or your preferred |
 | Login | Your workload user in CDP profile | Customer credentials |
 | Password | Workload password | Customer credentials |
@@ -112,8 +112,8 @@ must have already been created via the specified virtual cluster jobs API.
 | wait | bool | If set to true, the operator will wait for the job to complete in the target cluster. The task exit status will reflect the  status of the completed job. Default `True` |
 | timeout | int | The maximum time to wait in seconds for the job to complete if `wait=True`. If set to `None`, 0 or a negative number, the task will never time out. Default `0` |
 | job_poll_interval | int | The interval in seconds at which the target API is polled for the job status. Default `10` |
-| api_retries | int | The number of times to retry an API request in the event of a connection failure or non-fatal API error. Default `9` |
-| api_timeout | int | The timeout in seconds after which, if no response has been received from the API, a request should be abandoned and retried. Default `30` |
+| api_retries | int | The number of times to retry an API request in the event of a connection failure or non-fatal API error. The parameter can be used to overwrite the value used by the cde hook used by the operator. The value precedence is 'parameter' > 'env var' > 'airflow.cfg' > 'default'. The `AIRFLOW__CDE__DEFAULT_NUM_RETRIES` environmemt variable can be used to set the value. Default value in the cde hook: `9` |
+| api_timeout | int | The timeout in seconds after which, if no response has been received from the API, a request should be abandoned and retried. The parameter can be used to overwrite the value used by the cde hook. The value precedence is 'parameter' > 'env var' > 'airflow.cfg' > 'default'. The `AIRFLOW__CDE__DEFAULT_API_TIMEOUT` environmemt variable can be used to set the value. The timeout value for the job run status check is calculated separately. The tenth of the `api_timeout` value is used if it is not less than `CdeHook.DEFAULT_API_TIMEOUT // 10`. If it is less the `CdeHook.DEFAULT_API_TIMEOUT // 10` value will be used. Default value in the cde hook: `300` |
 
 Example CDE operator DAG snippet:
 ```python

--- a/cloudera_airflow_provider/setup.cfg
+++ b/cloudera_airflow_provider/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = cloudera-airflow-provider
-version = 2.0.1
+version = 2.1.0
 author= Cloudera
 description= Cloudera CDP Airflow Plugins
 


### PR DESCRIPTION
DEX-8214: increase the API timeout to make the job creation more robust

A system with less resources or under a higher load might
need more time to start a job. Timing out too soon will just
cause to trigger more jobs, which does not help.
Increasing the default timeout value should help in these situations.

New environment variables were introduces to be able to
fine tune the timeout and retry values.

Timeout can be onfigured separately for job submit, kill, status check.