### PR TITLE
DEX-9087 and DEX-9088

### DIFF
--- a/cloudera_airflow_provider/CHANGELOG.md
+++ b/cloudera_airflow_provider/CHANGELOG.md
@@ -4,9 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+
 ## [2.1.1] - 2023-02-21
 
-Added handling of HTTP 429 on job submission for retries.
+- Added handling of HTTP 429 on job submission for retries.
+- reduce the number of warnings in the logs if the `AIRFLOW__CDE__DEFAULT_NUM_RETRIES`
+  or `AIRFLOW__CDE__DEFAULT_API_TIMEOUT` config values are not set.
 
 ## [2.1.0] - 2023-02-01
 

--- a/cloudera_airflow_provider/CHANGELOG.md
+++ b/cloudera_airflow_provider/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.1.1] - 2023-02-21
+
+Added handling of HTTP 429 on job submission for retries.
+
 ## [2.1.0] - 2023-02-01
 
 New environment variables allow to modify the `api_retries` and

--- a/cloudera_airflow_provider/cloudera/airflow/providers/hooks/cde.py
+++ b/cloudera_airflow_provider/cloudera/airflow/providers/hooks/cde.py
@@ -453,6 +453,12 @@ class RetryHandler:
                         f" waiting for run {response.text.rstrip()} to finish"
                     )
                     return self.EXIT_RETRIES
+                elif response.status_code == 429:
+                    self.log.info(
+                        f"Request could not be processed, "
+                        + "reached rate limit of CDE API: {error_msg}. Retrying"
+                    )
+                    return self.CONTINUE_RETRIES
                 elif 500 <= response.status_code < 600:
                     return self.CONTINUE_RETRIES
                 else:

--- a/cloudera_airflow_provider/cloudera/airflow/providers/hooks/cde.py
+++ b/cloudera_airflow_provider/cloudera/airflow/providers/hooks/cde.py
@@ -131,9 +131,13 @@ class CdeHook(BaseHook):  # type: ignore
             num_retries_val = num_retries
         else:
             try:
-                num_retries_val = conf.getint('cde', 'DEFAULT_NUM_RETRIES')
+                num_retries_val = conf.getint(
+                    'cde', 'DEFAULT_NUM_RETRIES', fallback=CdeHook.DEFAULT_NUM_RETRIES
+                )
             except AirflowConfigException as acerr:
                 self.log.warning(acerr)
+                self.log.warning("Falling back to default num retries value: %s",
+                                 CdeHook.DEFAULT_NUM_RETRIES)
 
         self.num_retries = num_retries_val
 
@@ -142,9 +146,13 @@ class CdeHook(BaseHook):  # type: ignore
             api_timeout_val = api_timeout
         else:
             try:
-                api_timeout_val = conf.getint('cde', 'DEFAULT_API_TIMEOUT')
+                api_timeout_val = conf.getint(
+                    'cde', 'DEFAULT_API_TIMEOUT', fallback=CdeHook.DEFAULT_API_TIMEOUT
+                )
             except AirflowConfigException as acerr:
                 self.log.warning(acerr)
+                self.log.warning("Falling back to default api timeout value: %s",
+                                 CdeHook.DEFAULT_API_TIMEOUT)
 
         self.api_timeout = api_timeout_val
 

--- a/cloudera_airflow_provider/setup.cfg
+++ b/cloudera_airflow_provider/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = cloudera-airflow-provider
-version = 2.1.0
+version = 2.1.1
 author= Cloudera
 description= Cloudera CDP Airflow Plugins
 

--- a/cloudera_airflow_provider/tests/providers/cloudera/hooks/test_cde_hook.py
+++ b/cloudera_airflow_provider/tests/providers/cloudera/hooks/test_cde_hook.py
@@ -165,6 +165,30 @@ class CdeHookTest(unittest.TestCase):
                                              timeout=400,
                                              verify=mock.ANY)
 
+    @mock.patch.dict(os.environ, {"AIRFLOW__CDE__DEFAULT_API_TIMEOUT": "400asdf"})
+    @mock.patch(GET_CDE_AUTH_TOKEN_METHOD, return_value=VALID_CDE_TOKEN_AUTH_RESPONSE)
+    @mock.patch.object(Session, "send", return_value=_make_response(201, {"id": TEST_JOB_RUN_ID}, ""))
+    @mock.patch.object(BaseHook, "get_connection", return_value=_get_test_connection(host="abc.svc"))
+    def test_submit_job_failed_internal_connection_set_timeout_by_env(
+        self, connection_mock, session_send_mock, cde_mock: mock.Mock
+    ):
+        """Test a wrong api timeout value via the AIRFLOW__CDE__DEFAULT_API_TIMEOUT
+        environment variable, the default value should be used in this case."""
+        cde_hook = CdeHook()
+        run_id = cde_hook.submit_job(TEST_JOB_NAME)
+        self.assertEqual(run_id, TEST_JOB_RUN_ID)
+        cde_mock.assert_not_called()
+        connection_mock.assert_called()
+        session_send_mock.assert_called_with(
+            mock.ANY,
+            allow_redirects=mock.ANY,
+            cert=mock.ANY,
+            proxies=mock.ANY,
+            stream=mock.ANY,
+            timeout=CdeHook.DEFAULT_API_TIMEOUT,
+            verify=mock.ANY,
+        )
+
     @mock.patch(GET_CDE_AUTH_TOKEN_METHOD, return_value=VALID_CDE_TOKEN_AUTH_RESPONSE)
     @mock.patch.object(Session, "send", return_value=_make_response(201, None, ""))
     @mock.patch.object(BaseHook, "get_connection", return_value=TEST_DEFAULT_CONNECTION)
@@ -452,6 +476,38 @@ class CdeHookTest(unittest.TestCase):
         cde_mock.assert_called()
         connection_mock.assert_called()
         self.assertEqual(session_send_mock.call_count, 3)
+
+    @mock.patch.dict(os.environ, {"AIRFLOW__CDE__DEFAULT_NUM_RETRIES": "4asdf"})
+    @mock.patch(GET_CDE_AUTH_TOKEN_METHOD, return_value=VALID_CDE_TOKEN_AUTH_RESPONSE)
+    @mock.patch.object(
+        Session,
+        "send",
+        return_value=_make_response(201, {"id": TEST_JOB_RUN_ID}, ""),
+        side_effect=[
+            ConnectionError(),
+            ConnectionError(),
+            ConnectionError(),
+            ConnectionError(),
+            ConnectionError(),
+            ConnectionError(),
+            ConnectionError(),
+            ConnectionError(),
+            # Returns what is specified in return_value
+            mock.DEFAULT,
+        ],
+    )
+    @mock.patch.object(BaseHook, "get_connection", return_value=TEST_DEFAULT_CONNECTION)
+    def test_submit_job_custom_env_api_retries_success(self, connection_mock, session_send_mock, cde_mock):
+        """The default num retries value should be used if a wrong value is set via the
+        AIRFLOW__CDE_DEFAULT_NUM_RETRIES environment variable.
+        The call will succeed for the 9th call which is the CdeHook.DEFAULT_NUM_RETRIES value.
+        """
+        cde_hook = CdeHook()
+        run_id = cde_hook.submit_job(TEST_JOB_NAME)
+        self.assertEqual(run_id, TEST_JOB_RUN_ID)
+        cde_mock.assert_called()
+        connection_mock.assert_called()
+        self.assertEqual(session_send_mock.call_count, CdeHook.DEFAULT_NUM_RETRIES)
 
     @mock.patch(GET_CDE_AUTH_TOKEN_METHOD, return_value=VALID_CDE_TOKEN_AUTH_RESPONSE)
     @mock.patch.object(Session, "send", side_effect=ConnectionError())


### PR DESCRIPTION
- DEX-9087: Handle HTTP 429 on job submit retries.
- DEX-9088: reduce the number of warnings in the logs