### PR TITLE
2.1.3 version release

### DIFF
--- a/cloudera_airflow_provider/.pylintrc
+++ b/cloudera_airflow_provider/.pylintrc
@@ -70,79 +70,16 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use "--disable=all --enable=classes
 # --disable=W".
-disable=print-statement,
-        parameter-unpacking,
-        unpacking-in-except,
-        old-raise-syntax,
-        backtick,
-        long-suffix,
-        old-ne-operator,
-        old-octal-literal,
-        import-star-module-level,
-        non-ascii-bytes-literal,
-        raw-checker-failed,
+disable=raw-checker-failed,
         bad-inline-option,
         locally-disabled,
         file-ignored,
         suppressed-message,
         useless-suppression,
         use-symbolic-message-instead,
-        apply-builtin,
-        basestring-builtin,
-        buffer-builtin,
-        cmp-builtin,
-        coerce-builtin,
-        execfile-builtin,
-        file-builtin,
-        long-builtin,
-        raw_input-builtin,
-        reduce-builtin,
-        standarderror-builtin,
-        unicode-builtin,
-        xrange-builtin,
-        coerce-method,
-        delslice-method,
-        getslice-method,
-        setslice-method,
-        no-absolute-import,
-        old-division,
-        dict-iter-method,
-        dict-view-method,
-        next-method-called,
-        metaclass-assignment,
-        indexing-exception,
-        raising-string,
-        reload-builtin,
-        oct-method,
-        hex-method,
-        nonzero-method,
-        cmp-method,
-        input-builtin,
-        round-builtin,
-        intern-builtin,
-        unichr-builtin,
-        map-builtin-not-iterating,
-        zip-builtin-not-iterating,
-        range-builtin-not-iterating,
-        filter-builtin-not-iterating,
-        using-cmp-argument,
-        eq-without-hash,
-        div-method,
-        idiv-method,
-        rdiv-method,
-        exception-message-attribute,
-        invalid-str-codec,
-        sys-max-int,
-        bad-python3-import,
-        next-method-defined,
-        xreadlines-attribute,
-        exception-escape,
-        comprehension-escape,
-        bad-continuation,  # Throws incorrect errors, see https://github.com/ambv/black/issues/48
         duplicate-code,  # deemed unnecessary
         abstract-method,  # deemed unnecessary
         keyword-arg-before-vararg,  # deemed unnecessary
-        no-self-use,  # http://pylint-messages.wikidot.com/messages:r0201
         no-else-return,  # deemed unnecessary
         no-else-raise,  # deemed unnecessary
         too-many-format-args,  # Pylint fails on multiline string format
@@ -341,13 +278,6 @@ max-line-length=110
 
 # Maximum number of lines in a module.
 max-module-lines=1000
-
-# List of optional constructs for which whitespace checking is disabled. `dict-
-# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
-# `trailing-comma` allows a space between comma and closing bracket: (a, ).
-# `empty-line` allows space-only lines.
-no-space-check=trailing-comma,
-               dict-separator
 
 # Allow the body of a class to be on the same line as the declaration if body
 # contains single statement.

--- a/cloudera_airflow_provider/CHANGELOG.md
+++ b/cloudera_airflow_provider/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- CI fixes.
 - Add support for the Test connection functionality on the Airflow UI
 
 ## [2.1.2] - 2023-04-24

--- a/cloudera_airflow_provider/CHANGELOG.md
+++ b/cloudera_airflow_provider/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- Add support for the Test connection functionality on the Airflow UI
 
 ## [2.1.2] - 2023-04-24
 - Enhanced handling of HTTP 429 on job submission for retries.

--- a/cloudera_airflow_provider/CHANGELOG.md
+++ b/cloudera_airflow_provider/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
+## [2.1.3] - 2024-09-16
+- CDERunJobOperator 429 response code attempts are now counted separately during retries
+- TaskFlow decorator implementation for CDERunJobOperator
+- CdpAccessKeyV2TokenAuth is now usable with Private Cloud CDE deployments
 - CI fixes.
 - Add support for the Test connection functionality on the Airflow UI
 

--- a/cloudera_airflow_provider/README.md
+++ b/cloudera_airflow_provider/README.md
@@ -134,7 +134,7 @@ So essentially it is up to the server to control the waiting time of the client.
 If the Retry-After header is not found or cannot be parsed, the default retry interval of 4 seconds will be used.
 
 
-Example CDE operator DAG snippet:
+`CdeRunJobOperator` DAG snippet:
 ```python
 cde_task = CdeRunJobOperator(
     connection_id='my_vc_name',
@@ -144,6 +144,14 @@ cde_task = CdeRunJobOperator(
 )
 ```
 Please refer for complete [example DAG](../docs/examples/cde_operator_example.py).
+
+`@task.cde` DAG snippet:
+```python
+@task.cde
+def run_scala_pi() -> Union[None, str, Dict[str, Any]]:
+    return "example-scala-pi"
+```
+Please refer for complete [example DAG](../docs/examples/cde_taskflow_example.py).
 
 #### CdwExecuteQueryOperator
 

--- a/cloudera_airflow_provider/README.md
+++ b/cloudera_airflow_provider/README.md
@@ -51,9 +51,11 @@ Extra parameters for Cloudera Data Engineering connection for development use on
 | Parameter | Description | Default value |
 | :--- | :---- | :--- |
 | altus_iam_endpoint | Optional | https://iamapi.us-west-1.altus.cloudera.com |
-| ca_cert_path | Optional, custom ca certificates path | None |
+| ca_cert_path | Optional, custom ca certificates path used by CDE authentication | None |
 | cdp_endpoint | CDP service endpoint | https://api.us-west-1.cdp.cloudera.com |
 | insecure | Optional, insecure mode (no certs check) | False |
+| form_factor | Optional, ("public" or "private")| None |
+| ca_cert_path_access_key_auth | Optional, custom ca certificates path used by CDP workload token access generation | None |
 
 You can set up a connection according to the following snippet:
 

--- a/cloudera_airflow_provider/cloudera/airflow/providers/decorators/cde.py
+++ b/cloudera_airflow_provider/cloudera/airflow/providers/decorators/cde.py
@@ -1,0 +1,162 @@
+#  Cloudera Airflow Provider
+#  (C) Cloudera, Inc. 2021-2022
+#  All rights reserved.
+#  Applicable Open Source License: Apache License Version 2.0
+#
+#  NOTE: Cloudera open source products are modular software products
+#  made up of hundreds of individual components, each of which was
+#  individually copyrighted.  Each Cloudera open source product is a
+#  collective work under U.S. Copyright Law. Your license to use the
+#  collective work is as provided in your written agreement with
+#  Cloudera.  Used apart from the collective work, this file is
+#  licensed for your use pursuant to the open source license
+#  identified above.
+#
+#  This code is provided to you pursuant a written agreement with
+#  (i) Cloudera, Inc. or (ii) a third-party authorized to distribute
+#  this code. If you do not have a written agreement with Cloudera nor
+#  with an authorized and properly licensed third party, you do not
+#  have any rights to access nor to use this code.
+#
+#  Absent a written agreement with Cloudera, Inc. (“Cloudera”) to the
+#  contrary, A) CLOUDERA PROVIDES THIS CODE TO YOU WITHOUT WARRANTIES OF ANY
+#  KIND; (B) CLOUDERA DISCLAIMS ANY AND ALL EXPRESS AND IMPLIED
+#  WARRANTIES WITH RESPECT TO THIS CODE, INCLUDING BUT NOT LIMITED TO
+#  IMPLIED WARRANTIES OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY AND
+#  FITNESS FOR A PARTICULAR PURPOSE; (C) CLOUDERA IS NOT LIABLE TO YOU,
+#  AND WILL NOT DEFEND, INDEMNIFY, NOR HOLD YOU HARMLESS FOR ANY CLAIMS
+#  ARISING FROM OR RELATED TO THE CODE; AND (D)WITH RESPECT TO YOUR EXERCISE
+#  OF ANY RIGHTS GRANTED TO YOU FOR THE CODE, CLOUDERA IS NOT LIABLE FOR ANY
+#  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR
+#  CONSEQUENTIAL DAMAGES INCLUDING, BUT NOT LIMITED TO, DAMAGES
+#  RELATED TO LOST REVENUE, LOST PROFITS, LOSS OF INCOME, LOSS OF
+#  BUSINESS ADVANTAGE OR UNAVAILABILITY, OR LOSS OR CORRUPTION OF
+#  DATA.
+
+from __future__ import annotations
+
+import warnings
+from typing import Any, Callable, Collection, Mapping, Sequence
+
+from airflow.decorators.base import DecoratedOperator, TaskDecorator, task_decorator_factory
+from airflow.utils.context import Context, context_merge
+from airflow.utils.operator_helpers import determine_kwargs
+from airflow.utils.types import NOTSET
+from cloudera.airflow.providers.operators.cde import CdeRunJobOperator
+
+
+class _CDERunJobDecoratedOperator(DecoratedOperator, CdeRunJobOperator):
+    """
+    Wraps a Python callable and uses the callable return value to set the CdeRunJobOperator's parameters.
+    The return value must be either None, a string (job_name) or a dictionary where the keys are the names of
+    the CdeRunJobOperator's arguments. (def my_callable(): -> Union[None, str, Dict[str, Any]])
+    The callable's return value takes precedence over the decorator's arguments.
+
+    :param python_callable: A reference to an object that is callable.
+    :param op_kwargs: A dictionary of keyword arguments that will get unpacked
+        in your function (templated).
+    :param op_args: A list of positional arguments that will get unpacked when
+        calling your callable (templated).
+    """
+
+    template_fields: Sequence[str] = (*DecoratedOperator.template_fields, *CdeRunJobOperator.template_fields)
+    template_fields_renderers: dict[str, str] = {
+        **DecoratedOperator.template_fields_renderers,
+    }
+
+    custom_operator_name: str = "@task.cde"
+
+    def __init__(
+        self,
+        *,
+        python_callable: Callable,
+        op_args: Collection[Any] | None = None,
+        op_kwargs: Mapping[str, Any] | None = None,
+        **kwargs,
+    ) -> None:
+        if kwargs.pop("multiple_outputs", None):
+            warnings.warn(
+                f"`multiple_outputs=True` is not supported in {self.custom_operator_name} tasks. Ignoring.",
+                UserWarning,
+                stacklevel=3,
+            )
+
+        job_name = kwargs.pop("job_name", NOTSET)
+        super().__init__(
+            python_callable=python_callable,
+            op_args=op_args,
+            op_kwargs=op_kwargs,
+            job_name=job_name,
+            multiple_outputs=False,
+            **kwargs,
+        )
+
+    def execute(self, context: Context) -> Any:
+        context_merge(context, self.op_kwargs)
+        kwargs = determine_kwargs(self.python_callable, self.op_args, context)
+
+        parameters = self.python_callable(*self.op_args, **kwargs)
+
+        if parameters is None:
+            pass
+        elif isinstance(parameters, str):
+            self.job_name = parameters
+        elif isinstance(parameters, dict):
+
+            def pop_validate_set(param_name: str, cls: type):
+                value = parameters.pop(param_name, None)
+                if value is not None:
+                    if not isinstance(value, cls):
+                        raise TypeError(
+                            f"The returned parameter='{param_name}' from the TaskFlow callable "
+                            f"must be type={cls}. Got {type(value)}"
+                        )
+                    setattr(self, param_name, value)
+
+            pop_validate_set("job_name", str)
+            pop_validate_set("variables", dict)
+            pop_validate_set("overrides", dict)
+            pop_validate_set("connection_id", str)
+            pop_validate_set("wait", bool)
+            pop_validate_set("timeout", int)
+            pop_validate_set("job_poll_interval", int)
+            pop_validate_set("api_retries", int)
+            pop_validate_set("api_timeout", int)
+            # `user` is not supported
+
+            if not bool(parameters):
+                self.log.warning(
+                    f"The returned parameters from the TaskFlow callable "
+                    f"contain unsupported keys, ignoring: {parameters.keys()}"
+                )
+        else:
+            raise TypeError(
+                f"The returned parameters from the TaskFlow callable must be "
+                f"a Union[None, str, Dict[str, Any]]. Got: {type(parameters)}"
+            )
+
+        if self.job_name.strip() == "":
+            raise ValueError("job_name is required")
+
+        return super().execute(context)
+
+
+def cde_task(
+    python_callable: Callable | None = None,
+    **kwargs,
+) -> TaskDecorator:
+    """
+    Wrap a function into a CdeRunJobOperator.
+
+    Accepts kwargs for operator kwargs. Can be reused in a single DAG. This function is only used
+    during type checking or auto-completion.
+
+    :param python_callable: Function to decorate.
+
+    :meta private:
+    """
+    return task_decorator_factory(
+        python_callable=python_callable,
+        decorated_operator_class=_CDERunJobDecoratedOperator,
+        **kwargs,
+    )

--- a/cloudera_airflow_provider/cloudera/airflow/providers/hooks/cde.py
+++ b/cloudera_airflow_provider/cloudera/airflow/providers/hooks/cde.py
@@ -450,6 +450,10 @@ class CdeHook(BaseHook):  # type: ignore
                 region=self.connection.region,
                 cdp_endpoint=self.connection.cdp_endpoint,
                 altus_iam_endpoint=self.connection.altus_iam_endpoint,
+                insecure=self.connection.insecure,
+                custom_ca_path=self.connection.ca_cert_path_access_key_auth,
+                form_factor=self.connection.form_factor,
+                env_crn=self.connection.env_crn,
             )
 
             cache_mech_extra_kw = {}
@@ -472,7 +476,7 @@ class CdeHook(BaseHook):  # type: ignore
             )
             cde_token = cde_auth.get_cde_authentication_token().access_token
             self.log.debug("CDE token successfully acquired")
-            if not self.connection.region:
+            if not self.connection.region and cdp_auth.region is not None:
                 # Save region, so that any subsequent calls would not need to infer it again
                 self.log.debug(
                     "Saving inferred region %s to connection with connection_id %s",

--- a/cloudera_airflow_provider/cloudera/airflow/providers/hooks/cdw.py
+++ b/cloudera_airflow_provider/cloudera/airflow/providers/hooks/cdw.py
@@ -204,31 +204,32 @@ class CdwHook(HiveCliHook):
 
                 if verbose:
                     self.log.info("%s", " ".join(self._prepare_cli_cmd(hide_secrets=True)))
-                sub_process = subprocess.Popen(
+                with subprocess.Popen(
                     hive_cmd,
                     stdout=subprocess.PIPE,
                     stderr=subprocess.STDOUT,
                     cwd=tmp_dir,
                     close_fds=True,
                     start_new_session=True,
-                )
-                self.sub_process = sub_process
-                stdout = ""
-                while True:
-                    line = sub_process.stdout.readline()
-                    if not line:
-                        break
-                    stdout += line.decode("UTF-8")
-                    if verbose:
-                        self.log.info(line.decode("UTF-8").strip())
-                sub_process.wait()
+                ) as sub_process:
+                    self.sub_process = sub_process
+                    stdout = ""
+                    while True:
+                        line = sub_process.stdout.readline()
+                        if not line:
+                            break
+                        stdout += line.decode("UTF-8")
+                        if verbose:
+                            self.log.info(line.decode("UTF-8").strip())
+                    sub_process.wait()
 
-                if sub_process.returncode:
-                    raise AirflowException(stdout)
+                    if sub_process.returncode:
+                        raise AirflowException(stdout)
 
-                return stdout
+                    return stdout
 
     def kill(self):
+        """Kills the hive job."""
         if hasattr(self, "sub_process") and self.sub_process is not None:
             if self.sub_process.poll() is None:
                 print("Killing the Hive job")

--- a/cloudera_airflow_provider/cloudera/airflow/providers/model/connection.py
+++ b/cloudera_airflow_provider/cloudera/airflow/providers/model/connection.py
@@ -126,7 +126,8 @@ class CdeConnection(Connection):
         connection = session.query(Connection).filter_by(conn_id=self.conn_id).one_or_none()
         if not connection:
             LOG.warning(
-                "Can not save region. The connection with connection_id: %s was not found", self.conn_id
+                "Can not save region. The connection with connection_id: %s was not found",
+                self.conn_id,
             )
             return
         extra = json.loads(connection.extra) if connection.extra else {}

--- a/cloudera_airflow_provider/cloudera/airflow/providers/operators/cde.py
+++ b/cloudera_airflow_provider/cloudera/airflow/providers/operators/cde.py
@@ -149,6 +149,7 @@ class CdeRunJobOperator(BaseOperator):
     DEFAULT_TIMEOUT = 0
     DEFAULT_CONNECTION_ID = "cde_runtime_api"
 
+    # NOTE: keep the decorators/cde.py up to date with the CdeRunJobOperator's parameters
     def __init__(  # pylint: disable=too-many-arguments
         self,
         job_name: str,

--- a/cloudera_airflow_provider/cloudera/airflow/providers/operators/cdw.py
+++ b/cloudera_airflow_provider/cloudera/airflow/providers/operators/cdw.py
@@ -47,7 +47,7 @@ class CdwExecuteQueryOperator(BaseOperator):
     Executes hql code in CDW. This class inherits behavior
     from HiveOperator, and instantiates a CdwHook to do the work.
 
-    .. seealso::
+    :see:
         For more information on how to use this operator, take a look at the guide:
         :ref:`howto/operator:CdwExecuteQueryOperator`
     """
@@ -60,8 +60,9 @@ class CdwExecuteQueryOperator(BaseOperator):
     ui_color = "#522a9f"
     ui_fgcolor = "#fff"
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments
         self,
+        *args,
         hql,
         schema="default",
         hiveconfs=None,
@@ -71,7 +72,6 @@ class CdwExecuteQueryOperator(BaseOperator):
         # new CDW args
         use_proxy_user=False,  # pylint: disable=unused-argument
         query_isolation=True,  # TODO: implement
-        *args,
         **kwargs,
     ):
 
@@ -99,10 +99,12 @@ class CdwExecuteQueryOperator(BaseOperator):
         )
 
     def prepare_template(self):
+        """Prepare the template fields for rendering"""
         if self.hiveconf_jinja_translate:
             self.hql = re.sub(r"(\$\{(hiveconf:)?([ a-zA-Z0-9_]*)\})", r"{{ \g<3> }}", self.hql)
 
     def execute(self, context):
+        """Execute the query"""
         self.log.info("Executing: %s", self.hql)
         self.hook = self.get_hook()
 
@@ -115,9 +117,11 @@ class CdwExecuteQueryOperator(BaseOperator):
         self.hook.run_cli(hql=self.hql, schema=self.schema, hive_conf=self.hiveconfs)
 
     def dry_run(self):
+        """Dry run the query"""
         self.hook = self.get_hook()
         self.hook.test_hql(hql=self.hql)
 
     def on_kill(self):
+        """Kill the hive query"""
         if self.hook:
             self.hook.kill()

--- a/cloudera_airflow_provider/cloudera/airflow/providers/sensors/cdw.py
+++ b/cloudera_airflow_provider/cloudera/airflow/providers/sensors/cdw.py
@@ -39,6 +39,7 @@ from airflow.providers.apache.hive.sensors.hive_partition import HivePartitionSe
 from cloudera.airflow.providers.hooks.cdw import CdwHiveMetastoreHook
 
 
+# pylint: disable=too-many-ancestors; HivePartitionSensor is external
 class CdwHivePartitionSensor(HivePartitionSensor):
     """
     CdwHivePartitionSensor is a subclass of HivePartitionSensor and supposed to implement
@@ -71,6 +72,7 @@ class CdwHivePartitionSensor(HivePartitionSensor):
         self.schema = schema
         self.hook = None
 
+    # pylint: disable=unused-argument,missing-function-docstring; poke is overridden from the parent class
     def poke(self, context):
         if "." in self.table:
             self.schema, self.table = self.table.split(".")

--- a/cloudera_airflow_provider/cloudera/cdp/airflow/__init__.py
+++ b/cloudera_airflow_provider/cloudera/cdp/airflow/__init__.py
@@ -44,7 +44,8 @@ def get_provider_info():  # pragma: no cover , metadata only used for building
         "description": """Provides Operators for running jobs on CDE and CDW.
 Notes:
     - For Airflow 2.x a new dedicated connection type for CDE is available in the UI""",
-        # hook-class-names is deprecated as of Airflow 2.2.0, keeping it for backwards compatibility with older versions
+        # hook-class-names is deprecated as of Airflow 2.2.0,
+        # keeping it for backwards compatibility with older versions
         # https://airflow.apache.org/docs/apache-airflow-providers/index.html#how-to-create-your-own-provider
         "hook-class-names": [
             "cloudera.airflow.providers.hooks.cde.CdeHook",

--- a/cloudera_airflow_provider/requirements_tox.txt
+++ b/cloudera_airflow_provider/requirements_tox.txt
@@ -3,7 +3,7 @@ pytest==5.4.1
 pytest-mock==2.0.0
 py==1.9.0
 pluggy==0.13.1
-packaging==24
+packaging==20.3
 more-itertools==8.2.0
 wcwidth==0.1.8
 requests-mock==1.7.0

--- a/cloudera_airflow_provider/requirements_tox.txt
+++ b/cloudera_airflow_provider/requirements_tox.txt
@@ -3,7 +3,7 @@ pytest==5.4.1
 pytest-mock==2.0.0
 py==1.9.0
 pluggy==0.13.1
-packaging==20.3
+packaging==24
 more-itertools==8.2.0
 wcwidth==0.1.8
 requests-mock==1.7.0

--- a/cloudera_airflow_provider/setup.cfg
+++ b/cloudera_airflow_provider/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = cloudera-airflow-provider
-version = 2.1.2
+version = 2.1.3
 author= Cloudera
 description= Cloudera CDP Airflow Plugins
 

--- a/cloudera_airflow_provider/setup.cfg
+++ b/cloudera_airflow_provider/setup.cfg
@@ -15,6 +15,16 @@ install_requires=
   tenacity
   requests
   cloudera-cde-sdk>=1.0.1
+  # setuptools requirements
+  # more info: https://github.com/pypa/setuptools/issues/4483
+  packaging>=24; python_version >= "3.8"
+  ordered-set>=3.1.1; python_version >= "3.8"
+  more_itertools>=8.8; python_version >= "3.8"
+  importlib_resources>=5.10.2; python_version >= "3.8"
+  importlib_metadata>=6; python_version >= "3.8"
+  tomli>=2.0.1; python_version >= "3.8"
+  wheel>=0.43.0; python_version >= "3.8"
+  platformdirs >= 2.6.2; python_version >= "3.8"
 
 [options.entry_points]
 # Airflow 2 provider entrypoint

--- a/cloudera_airflow_provider/setup.cfg
+++ b/cloudera_airflow_provider/setup.cfg
@@ -6,7 +6,7 @@ description= Cloudera CDP Airflow Plugins
 
 [options]
 packages = find_namespace:
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires=
   apache-airflow
   apache-airflow-providers-apache-hive
@@ -15,16 +15,6 @@ install_requires=
   tenacity
   requests
   cloudera-cde-sdk>=1.0.1
-  # setuptools requirements
-  # more info: https://github.com/pypa/setuptools/issues/4483
-  packaging>=24; python_version >= "3.8"
-  ordered-set>=3.1.1; python_version >= "3.8"
-  more_itertools>=8.8; python_version >= "3.8"
-  importlib_resources>=5.10.2; python_version >= "3.8"
-  importlib_metadata>=6; python_version >= "3.8"
-  tomli>=2.0.1; python_version >= "3.8"
-  wheel>=0.43.0; python_version >= "3.8"
-  platformdirs >= 2.6.2; python_version >= "3.8"
 
 [options.entry_points]
 # Airflow 2 provider entrypoint
@@ -39,6 +29,6 @@ include =
 line_length=110
 combine_as_imports = true
 default_section = THIRDPARTY
-known_first_party=airflow,tests
+known_first_party=airflow,cloudera,tests
 skip=build,.tox,venv
 profile = black

--- a/cloudera_airflow_provider/setup.cfg
+++ b/cloudera_airflow_provider/setup.cfg
@@ -14,7 +14,7 @@ install_requires=
   cryptography>=3.3.2
   tenacity
   requests
-  cloudera-cde-sdk>=1.0.1
+  cloudera-cde-sdk>=1.0.2
 
 [options.entry_points]
 # Airflow 2 provider entrypoint

--- a/cloudera_airflow_provider/tests/cloudera/airflow/test_legacy_suffix_naming.py
+++ b/cloudera_airflow_provider/tests/cloudera/airflow/test_legacy_suffix_naming.py
@@ -36,7 +36,7 @@
 from unittest import TestCase, mock
 from unittest.mock import Mock
 
-from airflow.hooks.base_hook import BaseHook
+from airflow.hooks.base import BaseHook
 from airflow.models.connection import Connection
 from cloudera.airflow.providers.hooks.cde import CdeHook, CdeHookException
 from cloudera.airflow.providers.hooks.cdw import CdwHiveMetastoreHook, CdwHook

--- a/cloudera_airflow_provider/tests/cloudera/airflow/test_legacy_suffix_naming.py
+++ b/cloudera_airflow_provider/tests/cloudera/airflow/test_legacy_suffix_naming.py
@@ -82,6 +82,8 @@ TEST_DEFAULT_CONNECTION = Connection(
 
 
 class CdeRunJobOperatorTest(TestCase):
+    """Test cases for CdeRunJobOperator"""
+
     @mock.patch.object(
         CdeHook,
         'get_connection',

--- a/cloudera_airflow_provider/tests/providers/cloudera/decorators/test_cde.py
+++ b/cloudera_airflow_provider/tests/providers/cloudera/decorators/test_cde.py
@@ -1,0 +1,304 @@
+#  Cloudera Airflow Provider
+#  (C) Cloudera, Inc. 2021-2022
+#  All rights reserved.
+#  Applicable Open Source License: Apache License Version 2.0
+#
+#  NOTE: Cloudera open source products are modular software products
+#  made up of hundreds of individual components, each of which was
+#  individually copyrighted.  Each Cloudera open source product is a
+#  collective work under U.S. Copyright Law. Your license to use the
+#  collective work is as provided in your written agreement with
+#  Cloudera.  Used apart from the collective work, this file is
+#  licensed for your use pursuant to the open source license
+#  identified above.
+#
+#  This code is provided to you pursuant a written agreement with
+#  (i) Cloudera, Inc. or (ii) a third-party authorized to distribute
+#  this code. If you do not have a written agreement with Cloudera nor
+#  with an authorized and properly licensed third party, you do not
+#  have any rights to access nor to use this code.
+#
+#  Absent a written agreement with Cloudera, Inc. (“Cloudera”) to the
+#  contrary, A) CLOUDERA PROVIDES THIS CODE TO YOU WITHOUT WARRANTIES OF ANY
+#  KIND; (B) CLOUDERA DISCLAIMS ANY AND ALL EXPRESS AND IMPLIED
+#  WARRANTIES WITH RESPECT TO THIS CODE, INCLUDING BUT NOT LIMITED TO
+#  IMPLIED WARRANTIES OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY AND
+#  FITNESS FOR A PARTICULAR PURPOSE; (C) CLOUDERA IS NOT LIABLE TO YOU,
+#  AND WILL NOT DEFEND, INDEMNIFY, NOR HOLD YOU HARMLESS FOR ANY CLAIMS
+#  ARISING FROM OR RELATED TO THE CODE; AND (D)WITH RESPECT TO YOUR EXERCISE
+#  OF ANY RIGHTS GRANTED TO YOU FOR THE CODE, CLOUDERA IS NOT LIABLE FOR ANY
+#  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR
+#  CONSEQUENTIAL DAMAGES INCLUDING, BUT NOT LIMITED TO, DAMAGES
+#  RELATED TO LOST REVENUE, LOST PROFITS, LOSS OF INCOME, LOSS OF
+#  BUSINESS ADVANTAGE OR UNAVAILABILITY, OR LOSS OR CORRUPTION OF
+#  DATA.
+
+"""Tests related to the CDE Job operator"""
+
+from __future__ import annotations
+
+import unittest
+from datetime import datetime
+from unittest import mock
+
+import pytest
+from parameterized import parameterized
+
+from airflow.decorators import task
+from airflow.models.baseoperator import BaseOperator
+from airflow.models.connection import Connection
+from airflow.models.dag import DAG
+from airflow.models.taskinstance import TaskInstance
+from cloudera.airflow.providers.hooks.cde import CdeHook
+from cloudera.airflow.providers.operators.cde import CdeRunJobOperator
+
+TEST_JOB_NAME = "testjob"
+TEST_JOB_RUN_ID = 10
+TEST_AIRFLOW_DAG_ID = "dag_1"
+TEST_AIRFLOW_RUN_ID = "run_1"
+TEST_AIRFLOW_RUN_EXECUTION_DATE = datetime.now()
+TEST_AIRFLOW_TASK_ID = "task_1"
+TEST_TIMEOUT = 4
+TEST_JOB_POLL_INTERVAL = 1
+TEST_API_RETRIES = 3
+TEST_API_TIMEOUT = 5
+TEST_VARIABLES = {"var1": "someval_{{ ds_nodash }}"}
+TEST_OVERRIDES = {"spark": {"conf": {"myparam": "val_{{ ds_nodash }}"}}}
+TEST_CONTEXT = {
+    "ds": "2020-11-25",
+    "ds_nodash": "20201125",
+    "ts": "2020-11-25T00:00:00+00:00",
+    "ts_nodash": "20201125T000000",
+    "run_id": TEST_AIRFLOW_RUN_ID,
+}
+TEST_HOST = "vc1.cde-2.cdp-3.cloudera.site"
+TEST_SCHEME = "http"
+TEST_PORT = 9090
+TEST_AK = "access_key"
+TEST_PK = "private_key"
+TEST_CUSTOM_CA_CERTIFICATE = "/ca_cert/letsencrypt-stg-root-x1.pem"
+TEST_EXTRA = (
+    f'{{"access_key": "{TEST_AK}", "private_key": "{TEST_PK}", "ca_cert": "{TEST_CUSTOM_CA_CERTIFICATE}"}}'
+)
+
+TEST_DEFAULT_CONNECTION_DICT = {
+    "conn_id": CdeHook.DEFAULT_CONN_ID,
+    "conn_type": "http",
+    "host": TEST_HOST,
+    "port": TEST_PORT,
+    "schema": TEST_SCHEME,
+    "extra": TEST_EXTRA,
+}
+
+TEST_DEFAULT_CONNECTION = Connection(
+    conn_id=CdeHook.DEFAULT_CONN_ID,
+    conn_type="http",
+    host=TEST_HOST,
+    port=TEST_PORT,
+    schema=TEST_SCHEME,
+    extra=TEST_EXTRA,
+)
+
+
+def mock_task_instance_for_context():
+    """Mocks task_instance for test context."""
+    TEST_CONTEXT["task_instance"] = TaskInstance(
+        execution_date=TEST_AIRFLOW_RUN_EXECUTION_DATE,
+        task=BaseOperator(
+            task_id=TEST_AIRFLOW_TASK_ID, dag=DAG(TEST_AIRFLOW_DAG_ID, start_date=datetime.now())
+        ),
+    )
+
+
+@mock.patch('sqlalchemy.orm.Query.scalar', return_value=TEST_AIRFLOW_RUN_ID)
+@mock.patch.object(CdeHook, "submit_job", return_value=TEST_JOB_RUN_ID)
+@mock.patch.object(CdeHook, "check_job_run_status", side_effect=["starting", "running", "succeeded"])
+@mock.patch.object(CdeHook, "get_connection", return_value=TEST_DEFAULT_CONNECTION)
+class CdeRunJobTaskTest(unittest.TestCase):
+    """Unit tests for @task.cde"""
+
+    @parameterized.expand(
+        [
+            [
+                ["invalid", "return"],
+                r"The returned parameters from the TaskFlow callable must be a Union.*Got.*'list'.*",
+            ],
+            [
+                {"job_name": ["invalid"]},
+                r"The returned parameter='job_name' from the TaskFlow callable.*Got.*'list'.*",
+            ],
+            [
+                {"job_name": TEST_JOB_NAME, "variables": "invalid"},
+                r"The returned parameter='variables' from the TaskFlow callable.*Got.*'str'.*",
+            ],
+            [
+                {"job_name": TEST_JOB_NAME, "overrides": "invalid"},
+                r"The returned parameter='overrides' from the TaskFlow callable.*Got.*'str'.*",
+            ],
+            [
+                {"job_name": TEST_JOB_NAME, "connection_id": {}},
+                r"The returned parameter='connection_id' from the TaskFlow callable.*Got.*'dict'.*",
+            ],
+            [
+                {"job_name": TEST_JOB_NAME, "wait": {}},
+                r"The returned parameter='wait' from the TaskFlow callable.*Got.*'dict'.*",
+            ],
+            [
+                {"job_name": TEST_JOB_NAME, "timeout": {}},
+                r"The returned parameter='timeout' from the TaskFlow callable.*Got.*'dict'.*",
+            ],
+            [
+                {"job_name": TEST_JOB_NAME, "job_poll_interval": {}},
+                r"The returned parameter='job_poll_interval' from the TaskFlow callable.*Got.*'dict'.*",
+            ],
+            [
+                {"job_name": TEST_JOB_NAME, "api_retries": {}},
+                r"The returned parameter='api_retries' from the TaskFlow callable.*Got.*'dict'.*",
+            ],
+            [
+                {"job_name": TEST_JOB_NAME, "api_timeout": {}},
+                r"The returned parameter='api_timeout' from the TaskFlow callable.*Got.*'dict'.*",
+            ],
+        ]
+    )
+    def test_task_fail_invalid_return_types(
+        self, get_connection, check_job_run_status, submit_job, scalar, return_value, expected_error
+    ):
+        """Test invalid return types for the python callable."""
+
+        # pylint: disable=unused-argument
+        @task.cde
+        def task_cde():
+            return return_value
+
+        mock_task_instance_for_context()
+        operator = task_cde().operator  # pylint: disable=E1101
+        with pytest.raises(TypeError, match=expected_error):
+            operator.execute(TEST_CONTEXT)
+
+    def test_task_fail_job_name_required(self, get_connection, check_job_run_status, submit_job, scalar):
+        """Test missing job name."""
+
+        # pylint: disable=unused-argument
+        @task.cde
+        def task_cde():
+            return ""
+
+        mock_task_instance_for_context()
+        operator = task_cde().operator  # pylint: disable=E1101
+        with pytest.raises(ValueError, match=r"job_name is required"):
+            operator.execute(TEST_CONTEXT)
+
+    def test_task_default_args(self, get_connection, check_job_run_status, submit_job, scalar):
+        """Test the default arguments with a returned job name."""
+
+        # pylint: disable=unused-argument
+        @task.cde
+        def task_cde():
+            return TEST_JOB_NAME
+
+        mock_task_instance_for_context()
+        operator = task_cde().operator  # pylint: disable=E1101
+        operator.execute(TEST_CONTEXT)
+        self.assert_defaults(operator)
+
+    def test_task_default_args_decorator(self, get_connection, check_job_run_status, submit_job, scalar):
+        """Test that job name can be specified in the decorator arguments."""
+
+        # pylint: disable=unused-argument
+        @task.cde(job_name=TEST_JOB_NAME)
+        def task_cde():
+            return None
+
+        mock_task_instance_for_context()
+        operator = task_cde().operator  # pylint: disable=E1101
+        operator.execute(TEST_CONTEXT)
+        self.assert_defaults(operator)
+
+    def test_task_args_decorator(self, get_connection, check_job_run_status, submit_job, scalar):
+        """Test task decorator arguments."""
+
+        # pylint: disable=unused-argument
+        @task.cde(
+            job_name=TEST_JOB_NAME,
+            variables=TEST_VARIABLES,
+            overrides=TEST_OVERRIDES,
+            connection_id="connection_id",
+            wait=False,
+            timeout=TEST_TIMEOUT,
+            job_poll_interval=TEST_JOB_POLL_INTERVAL,
+            api_retries=TEST_API_RETRIES,
+            api_timeout=TEST_API_TIMEOUT,
+        )
+        def task_cde():
+            return None
+
+        mock_task_instance_for_context()
+        operator = task_cde().operator  # pylint: disable=E1101
+        operator.execute(TEST_CONTEXT)
+        self.assert_custom(operator)
+
+    def test_task_args_precedence(self, get_connection, check_job_run_status, submit_job, scalar):
+        """Test returned parameters takes precedence over decorator's arguments."""
+
+        # pylint: disable=unused-argument
+        @task.cde(
+            job_name="job",
+            variables={},
+            overrides={},
+            connection_id="connection_id_2",
+            wait=True,
+            timeout=11,
+            job_poll_interval=22,
+            api_retries=33,
+            api_timeout=44,
+        )
+        def task_cde():
+            return {
+                "job_name": TEST_JOB_NAME,
+                "variables": TEST_VARIABLES,
+                "overrides": TEST_OVERRIDES,
+                "connection_id": "connection_id",
+                "wait": False,
+                "timeout": TEST_TIMEOUT,
+                "job_poll_interval": TEST_JOB_POLL_INTERVAL,
+                "api_retries": TEST_API_RETRIES,
+                "api_timeout": TEST_API_TIMEOUT,
+                "user": 'silently_ignored',
+                "abc": "sliently_ignored",
+            }
+
+        mock_task_instance_for_context()
+        operator = task_cde().operator  # pylint: disable=E1101
+        operator.execute(TEST_CONTEXT)
+        self.assert_custom(operator)
+
+    def assert_defaults(self, operator):
+        """Asserts the default operator properties."""
+        self.assertEqual(operator.job_name, TEST_JOB_NAME)
+        self.assertEqual(operator.variables, {})
+        self.assertEqual(operator.overrides, {})
+        self.assertEqual(operator.connection_id, CdeRunJobOperator.DEFAULT_CONNECTION_ID)
+        self.assertEqual(operator.wait, CdeRunJobOperator.DEFAULT_WAIT)
+        self.assertEqual(operator.timeout, CdeRunJobOperator.DEFAULT_TIMEOUT)
+        self.assertEqual(operator.job_poll_interval, CdeRunJobOperator.DEFAULT_POLL_INTERVAL)
+        self.assertEqual(operator.api_retries, None)
+        self.assertEqual(operator.api_timeout, None)
+        self.assertEqual(operator.user, None)
+
+    def assert_custom(self, operator):
+        """Asserts the test operator properties."""
+        self.assertEqual(operator.job_name, TEST_JOB_NAME)
+        self.assertEqual(operator.variables, TEST_VARIABLES)
+        self.assertEqual(operator.overrides, TEST_OVERRIDES)
+        self.assertEqual(operator.connection_id, "connection_id")
+        self.assertEqual(operator.wait, False)
+        self.assertEqual(operator.timeout, TEST_TIMEOUT)
+        self.assertEqual(operator.job_poll_interval, TEST_JOB_POLL_INTERVAL)
+        self.assertEqual(operator.api_retries, TEST_API_RETRIES)
+        self.assertEqual(operator.api_timeout, TEST_API_TIMEOUT)
+        self.assertEqual(operator.user, None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cloudera_airflow_provider/tests/providers/cloudera/operators/test_cde_job_run_operator.py
+++ b/cloudera_airflow_provider/tests/providers/cloudera/operators/test_cde_job_run_operator.py
@@ -162,15 +162,15 @@ class CdeRunJobOperatorTest(unittest.TestCase):
         self.assertEqual(cde_operator.wait, CdeRunJobOperator.DEFAULT_WAIT)
         self.assertEqual(cde_operator.timeout, CdeRunJobOperator.DEFAULT_TIMEOUT)
         self.assertEqual(cde_operator.job_poll_interval, CdeRunJobOperator.DEFAULT_POLL_INTERVAL)
-        self.assertEqual(cde_operator.api_retries, None) # the value will be set only int the hook
-        self.assertEqual(cde_operator.api_timeout, None) # the value will be set only int the hook
+        self.assertEqual(cde_operator.api_retries, None)  # the value will be set only int the hook
+        self.assertEqual(cde_operator.api_timeout, None)  # the value will be set only int the hook
         # Make sure that retries and timeout are passed to the hook object. Retry and timeout behaviours
         # are tested in CdeHook unit tests
         self.assertEqual(cde_operator.get_hook().num_retries, 4)
         self.assertEqual(cde_operator.get_hook().api_timeout, 10)
 
-    @mock.patch.dict(os.environ, {"AIRFLOW__CDE__DEFAULT_API_TIMEOUT": str(TEST_API_TIMEOUT+2)})
-    @mock.patch.dict(os.environ, {"AIRFLOW__CDE__DEFAULT_NUM_RETRIES": str(TEST_API_RETRIES+2)})
+    @mock.patch.dict(os.environ, {"AIRFLOW__CDE__DEFAULT_API_TIMEOUT": str(TEST_API_TIMEOUT + 2)})
+    @mock.patch.dict(os.environ, {"AIRFLOW__CDE__DEFAULT_NUM_RETRIES": str(TEST_API_RETRIES + 2)})
     def test_init_override_env_value(self, get_connection: Mock):
         """Test if the constructor values override the env vars for the timeout and retry."""
         cde_operator = CdeRunJobOperator(

--- a/cloudera_airflow_provider/tests/providers/cloudera/utils.py
+++ b/cloudera_airflow_provider/tests/providers/cloudera/utils.py
@@ -39,7 +39,7 @@ from __future__ import annotations
 import logging
 from itertools import tee
 from json import dumps
-from typing import Any, Iterable, List, Tuple
+from typing import Any, Iterable
 
 from requests import Response
 
@@ -68,21 +68,21 @@ def _make_response(status: int, body, reason: str, headers: list[tuple[str, str]
     content = (
         b""
         if body == b""
-        else None
-        if body is None
-        else dumps(body).encode("utf-8")
-        if isinstance(body, dict)
-        else body.encode("utf-8")
+        else (
+            None
+            if body is None
+            else dumps(body).encode("utf-8") if isinstance(body, dict) else body.encode("utf-8")
+        )
     )
 
     resp = Response()
     resp.status_code = status
     resp.encoding = "utf-8"
-    resp._content = content
+    resp._content = content  # pylint: disable=protected-access
     resp.reason = reason
 
     if headers:
-        for h in headers:
-            resp.headers[h[0]] = h[1]
+        for header in headers:
+            resp.headers[header[0]] = header[1]
 
     return resp

--- a/cloudera_airflow_provider/tests/providers/cloudera/utils.py
+++ b/cloudera_airflow_provider/tests/providers/cloudera/utils.py
@@ -42,8 +42,10 @@ from json import dumps
 from typing import Any, Iterable, List, Tuple
 
 from requests import Response
+
 LOG = logging.getLogger(__name__)
 LOG.setLevel(logging.DEBUG)
+
 
 def iter_len_plus_one(iterator: Iterable) -> int:
     """Return the length + 1 of the given iterator.
@@ -62,7 +64,7 @@ def _get_call_arguments(self: tuple) -> dict[str, Any]:
     return kwargs
 
 
-def _make_response(status: int, body, reason: str, headers: List[Tuple[str, str]] = None) -> Response:
+def _make_response(status: int, body, reason: str, headers: list[tuple[str, str]] = None) -> Response:
     content = (
         b""
         if body == b""

--- a/cloudera_airflow_provider/tox.ini
+++ b/cloudera_airflow_provider/tox.ini
@@ -7,7 +7,7 @@ setenv =
     # This locale export is needed for 3.7.1 env otherwise airflow fails
     LC_ALL = "en_US.UTF-8"
 deps =
-    -rrequirements_tox.txt
+    -r requirements_tox.txt
 commands = python3 -m pytest 
 
 [testenv:pylint]

--- a/cloudera_airflow_provider/tox.ini
+++ b/cloudera_airflow_provider/tox.ini
@@ -1,10 +1,9 @@
 [tox]
-envlist = pylint, py36, py37, py38
+envlist = pylint, py{38,39,310,311,312}
 
 [testenv]
 setenv = 
     PYTHONPATH = {toxinidir}
-    # This locale export is needed for 3.7.1 env otherwise airflow fails
     LC_ALL = "en_US.UTF-8"
 deps =
     -r requirements_tox.txt

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -5,5 +5,5 @@ This directory contains example Directed Acyclic Graphs for Apache Airflow.
 They are:
 
 - [CdeRunJobOperator](cde_operator_example.py) example DAG.
-
+- [CdeRunJobOperator with TaskFlow API](cde_taskflow_example.py) example DAG.
 - [CdwExecuteQueryOperator](cdw_operator_example.py) example DAG.


### PR DESCRIPTION
PR includes:
- DEX-9608: Enable test for the connection created using CDE provider
- DEX-14426: Fix failing tests and update matrix in cloudera-airflow-plugins repo
- DEX-9654. Make CdpAccessKeyV2TokenAuth usable with Private Cloud CDE deployments.
- DEX-13759. TaskFlow decorator implementation for CDERunJobOperator.
- DEX-10769: Airflow retry handler does not retry a non 429 error.
- Bump version to v2.1.3

 ✅ Requires cloudera-cde-sdk v1.0.2 (https://github.com/cloudera/cloudera-airflow-plugins/pull/19)

Tested on:
✅ Local setup with Airflow 2.2.5 + python 3.8
✅ CDE cluster with Airflow 2.9.3 + python 3.11
✅ UTs